### PR TITLE
Fix #23: Utilize Promises for callback handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,13 +19,33 @@ Gulp pipeline that provides several utility methods to facilitate the creation o
 
 ### clean
 
-This functions provides a way to delete directories synchonrously, by passing an array of globs.
+#### Asynchronous
+
+This function provides a way to delete directories asynchronously, by passing an array of globs.
 
 ```javascript
 var handyman = require('pipeline-handyman');
 
-handyman.clean(['.dest/'], doneCallbackFunction);
+handyman.clean(['./dest'])
+  .then(function (arrayOfDeletedFilePaths) {
+    // do something after files are deleted
+  })
+  .catch(function (err) {
+    // do something with an error
+  });
 ```
+
+
+#### Synchronous
+
+This function provides a way to delete directories synchronously, by passing an array of globs.
+
+```javascript
+var handyman = require('pipeline-handyman');
+
+handyman.cleanSync(['./dest']); // returns an array of file paths that were removed.
+```
+
 
 ### getPackageName
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -12,9 +12,16 @@ var config = {
   ]
 };
 
-gulp.task('build', function() {
+gulp.task('test', ['lint'], function() {
   return gulp
     .src(config.jsFiles)
-    .pipe(validatePipeline.validateJS())
     .pipe(testPipeline.test());
 });
+
+gulp.task('lint', function() {
+  return gulp
+    .src(config.jsFiles)
+    .pipe(validatePipeline.validateJS());
+});
+
+gulp.task('build', ['test']);

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "chai": "3.4.0",
     "pipeline-test-node": "1.0.1",
     "pipeline-validate-js": "1.0.0-rc3",
-    "sinon": "1.17.2"
+    "sinon": "1.17.2",
+    "sinon-chai": "2.8.0"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -7,12 +7,17 @@ var fs = require('fs');
 var util = require('gulp-util');
 
 module.exports = {
+  clean: clean,
   cleanSync: cleanSync,
   getPackageName: getPackageName,
   log: log,
   mergeConfig: mergeConfig,
   slugify: slugify
 };
+
+function clean (path, options) {
+  return del(path, options);
+}
 
 function cleanSync(path, options) {
   return del.sync(path, options);

--- a/src/index.js
+++ b/src/index.js
@@ -7,15 +7,15 @@ var fs = require('fs');
 var util = require('gulp-util');
 
 module.exports = {
-  clean: clean,
+  cleanSync: cleanSync,
   getPackageName: getPackageName,
   log: log,
   mergeConfig: mergeConfig,
   slugify: slugify
 };
 
-function clean(path, done) {
-  return del.sync(path, done);
+function cleanSync(path, options) {
+  return del.sync(path, options);
 }
 
 function mergeConfig(config, newConfig) {

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -1,24 +1,65 @@
 /* jshint -W030 */
 'use strict';
 
-var expect = require('chai').expect;
+var chai = require('chai');
+var expect = chai.expect;
 var fs = require('fs');
 var handyman = require('../');
 var packageName = require('../package.json').name;
 var sinon = require('sinon');
+var sinonChai = require('sinon-chai');
 var util = require('gulp-util');
+var del = require('del');
+
+chai.use(sinonChai);
 
 describe('gulp-handyman', function () {
 
-  describe('clean', function () {
-    it('should delete the path passed as a param', function () {
-      var dir = './tmp';
+  describe('clean directories', function () {
+    var dir = './tmp';
 
-      fs.mkdirSync(dir);
-      handyman.clean([dir], null, true);
-
-      expect(fs.existsSync(dir)).to.be.false;
+    beforeEach(function () {
+      if (!fs.existsSync(dir)) {
+        fs.mkdirSync(dir);
+      }
     });
+
+    afterEach(function () {
+      if (fs.existsSync(dir)) {
+        del.sync(dir);
+      }
+    });
+
+    describe('cleanSync method', function () {
+
+      it('should expose a cleanSync method', function () {
+        expect(handyman.cleanSync).to.exist;
+      });
+
+      it('should return an array of deleted directories/files', function () {
+        var result = handyman.cleanSync([dir]);
+
+        expect(result).to.be.an.array;
+        expect(result[0]).to.contain('tmp');
+      });
+
+      it('should delete the path passed as a param', function () {
+        handyman.cleanSync([dir]);
+
+        expect(fs.existsSync(dir)).to.be.false;
+      });
+
+      it('should pass options to del.sync method', function () {
+        var spy = sinon.spy(del, 'sync');
+        var opts = {dryRun: true};
+
+        handyman.cleanSync([dir], {dryRun: true});
+
+        expect(spy).to.have.been.calledWith(sinon.match.array, opts);
+      });
+
+    });
+
   });
 
   describe('Update configuration', function () {
@@ -90,7 +131,7 @@ describe('gulp-handyman', function () {
     it('Should get package name from package.json', function () {
 
       var handyPackageName = handyman.getPackageName();
-      
+
       expect(handyPackageName).to.equal(packageName);
     });
 
@@ -108,7 +149,7 @@ describe('gulp-handyman', function () {
       expect(handyman.slugify(input)).to.equal(input);
     });
 
-    it('should replace all spaces with hyphens', function() {
+    it('should replace all spaces with hyphens', function () {
       input = 'input with spaces';
       expect(handyman.slugify(input)).to.equal('input-with-spaces');
     });
@@ -118,7 +159,7 @@ describe('gulp-handyman', function () {
       expect(handyman.slugify(input)).to.equal('input-with-capital-characters');
     });
 
-    it('should strip out non-alpha characters', function() {
+    it('should strip out non-alpha characters', function () {
       input = 'input with & some % special characters';
       expect(handyman.slugify(input)).to.equal('input-with-some-special-characters');
     });

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -54,7 +54,7 @@ describe('gulp-handyman', function () {
         var spy = sinon.spy(del, 'sync');
         var opts = { dryRun: true };
 
-        handyman.cleanSync([dir], { dryRun: true });
+        handyman.cleanSync([dir], opts);
 
         expect(spy).to.have.been.calledWith(sinon.match.array, opts);
       });

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -1,4 +1,5 @@
-/* jshint -W030 */
+/* eslint max-depth: ["error", 10] max-nested-callbacks: ["error", 10] */
+
 'use strict';
 
 var chai = require('chai');
@@ -51,11 +52,35 @@ describe('gulp-handyman', function () {
 
       it('should pass options to del.sync method', function () {
         var spy = sinon.spy(del, 'sync');
-        var opts = {dryRun: true};
+        var opts = { dryRun: true };
 
-        handyman.cleanSync([dir], {dryRun: true});
+        handyman.cleanSync([dir], { dryRun: true });
 
         expect(spy).to.have.been.calledWith(sinon.match.array, opts);
+      });
+
+    });
+
+    describe('clean method', function () {
+
+      it('should expose a clean method', function () {
+        expect(handyman.clean).to.exist;
+      });
+
+      it('should return a Promise object', function () {
+        var result = handyman.clean([dir]);
+
+        expect(result.then).to.exist;
+        expect(result.then).to.be.a('function');
+      });
+
+      it('should delete the path passed as a param', function (done) {
+        handyman.clean([dir])
+          .then(function () {
+            expect(fs.existsSync(dir)).to.be.false;
+            done();
+
+          });
       });
 
     });


### PR DESCRIPTION
**Associated Ticket**
https://github.com/kenzanlabs/pipeline-handyman/issues/23

**Changes Made**
- Rename original `clean` method to `cleanSync` to indicate synchronous deletion
- Increase tests for `cleanSync` method
- Create new `clean` method for async deletion returning a Promise
- Add tests for `clean` method
- Refactor the gulp tasks to separate concerns

**Reviewers**
@obuckley-kenzan @bsawyer @thisgeek 